### PR TITLE
Avoid per-row allocations

### DIFF
--- a/src/encoder/colortype.rs
+++ b/src/encoder/colortype.rs
@@ -2,16 +2,27 @@ use crate::tags::{PhotometricInterpretation, SampleFormat};
 
 macro_rules! integer_horizontal_predict {
     () => {
-        fn horizontal_predict(row: &[Self::Inner]) -> Vec<Self::Inner> {
+        fn horizontal_predict(row: &[Self::Inner], result: &mut Vec<Self::Inner>) {
             let sample_size = Self::SAMPLE_FORMAT.len();
-            let mut result = Vec::with_capacity(row.len());
+            if row.len() < sample_size {
+                debug_assert!(false);
+                return;
+            }
+            let (start, rest) = row.split_at(sample_size);
 
-            result.extend_from_slice(&row[0..=sample_size - 1]);
+            result.clear();
+            if result.capacity() - result.len() < row.len() {
+                return;
+            }
+            result.extend_from_slice(start);
+            if result.capacity() - result.len() < rest.len() {
+                return;
+            }
             result.extend(
-                (sample_size..row.len()).map(|i| row[i].wrapping_sub(row[i - sample_size])),
+                row.into_iter()
+                    .zip(rest)
+                    .map(|(prev, current)| current.wrapping_sub(*prev)),
             );
-
-            result
         }
     };
 }
@@ -27,7 +38,7 @@ pub trait ColorType {
     /// The value of the tiff tag `SampleFormat`
     const SAMPLE_FORMAT: &'static [SampleFormat];
 
-    fn horizontal_predict(row: &[Self::Inner]) -> Vec<Self::Inner>;
+    fn horizontal_predict(row: &[Self::Inner], result: &mut Vec<Self::Inner>);
 }
 
 pub struct Gray8;
@@ -97,7 +108,7 @@ impl ColorType for Gray32Float {
     const BITS_PER_SAMPLE: &'static [u16] = &[32];
     const SAMPLE_FORMAT: &'static [SampleFormat] = &[SampleFormat::IEEEFP];
 
-    fn horizontal_predict(_: &[Self::Inner]) -> Vec<Self::Inner> {
+    fn horizontal_predict(_: &[Self::Inner], _: &mut Vec<Self::Inner>) {
         unreachable!()
     }
 }
@@ -129,7 +140,7 @@ impl ColorType for Gray64Float {
     const BITS_PER_SAMPLE: &'static [u16] = &[64];
     const SAMPLE_FORMAT: &'static [SampleFormat] = &[SampleFormat::IEEEFP];
 
-    fn horizontal_predict(_: &[Self::Inner]) -> Vec<Self::Inner> {
+    fn horizontal_predict(_: &[Self::Inner], _: &mut Vec<Self::Inner>) {
         unreachable!()
     }
 }
@@ -170,7 +181,7 @@ impl ColorType for RGB32Float {
     const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
     const BITS_PER_SAMPLE: &'static [u16] = &[32, 32, 32];
     const SAMPLE_FORMAT: &'static [SampleFormat] = &[SampleFormat::IEEEFP; 3];
-    fn horizontal_predict(_: &[Self::Inner]) -> Vec<Self::Inner> {
+    fn horizontal_predict(_: &[Self::Inner], _: &mut Vec<Self::Inner>) {
         unreachable!()
     }
 }
@@ -191,7 +202,7 @@ impl ColorType for RGB64Float {
     const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
     const BITS_PER_SAMPLE: &'static [u16] = &[64, 64, 64];
     const SAMPLE_FORMAT: &'static [SampleFormat] = &[SampleFormat::IEEEFP; 3];
-    fn horizontal_predict(_: &[Self::Inner]) -> Vec<Self::Inner> {
+    fn horizontal_predict(_: &[Self::Inner], _: &mut Vec<Self::Inner>) {
         unreachable!()
     }
 }
@@ -232,7 +243,7 @@ impl ColorType for RGBA32Float {
     const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
     const BITS_PER_SAMPLE: &'static [u16] = &[32, 32, 32, 32];
     const SAMPLE_FORMAT: &'static [SampleFormat] = &[SampleFormat::IEEEFP; 4];
-    fn horizontal_predict(_: &[Self::Inner]) -> Vec<Self::Inner> {
+    fn horizontal_predict(_: &[Self::Inner], _: &mut Vec<Self::Inner>) {
         unreachable!()
     }
 }
@@ -253,7 +264,7 @@ impl ColorType for RGBA64Float {
     const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
     const BITS_PER_SAMPLE: &'static [u16] = &[64, 64, 64, 64];
     const SAMPLE_FORMAT: &'static [SampleFormat] = &[SampleFormat::IEEEFP; 4];
-    fn horizontal_predict(_: &[Self::Inner]) -> Vec<Self::Inner> {
+    fn horizontal_predict(_: &[Self::Inner], _: &mut Vec<Self::Inner>) {
         unreachable!()
     }
 }
@@ -295,7 +306,7 @@ impl ColorType for CMYK32Float {
     const BITS_PER_SAMPLE: &'static [u16] = &[32, 32, 32, 32];
     const SAMPLE_FORMAT: &'static [SampleFormat] = &[SampleFormat::IEEEFP; 4];
 
-    fn horizontal_predict(_: &[Self::Inner]) -> Vec<Self::Inner> {
+    fn horizontal_predict(_: &[Self::Inner], _: &mut Vec<Self::Inner>) {
         unreachable!()
     }
 }
@@ -317,7 +328,7 @@ impl ColorType for CMYK64Float {
     const BITS_PER_SAMPLE: &'static [u16] = &[64, 64, 64, 64];
     const SAMPLE_FORMAT: &'static [SampleFormat] = &[SampleFormat::IEEEFP; 4];
 
-    fn horizontal_predict(_: &[Self::Inner]) -> Vec<Self::Inner> {
+    fn horizontal_predict(_: &[Self::Inner], _: &mut Vec<Self::Inner>) {
         unreachable!()
     }
 }


### PR DESCRIPTION
The changes in `horizontal_predict` are just a dance to avoid panics and let LLVM vectorize the loop.
